### PR TITLE
Makes `Result.Calc.sum/2` and `Result.Calc.product/2` private.

### DIFF
--- a/lib/result/calc.ex
+++ b/lib/result/calc.ex
@@ -102,7 +102,7 @@ defmodule Result.Calc do
     product(list, {:ok, []})
   end
 
-  def product([head | tail], acc) do
+  defp product([head | tail], acc) do
     result =
       acc
       |> r_and(head)
@@ -111,7 +111,7 @@ defmodule Result.Calc do
     product(tail, result)
   end
 
-  def product([], acc) do
+  defp product([], acc) do
     acc
   end
 

--- a/lib/result/calc.ex
+++ b/lib/result/calc.ex
@@ -146,7 +146,7 @@ defmodule Result.Calc do
     sum(list, {:error, []})
   end
 
-  def sum([head | tail], acc) do
+  defp sum([head | tail], acc) do
     result =
       acc
       |> r_or(head)
@@ -155,7 +155,7 @@ defmodule Result.Calc do
     sum(tail, result)
   end
 
-  def sum([], acc) do
+  defp sum([], acc) do
     acc
   end
 


### PR DESCRIPTION
This closes #4.

By making these function declarations private, they no longer show up in the docs.